### PR TITLE
Release 0.5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,12 @@ push:
 	@docker push victorskl/g3po:latest
 	@docker push quay.io/victorskl/g3po:latest
 	@docker push quay.io/umccr/g3po:latest
+
+# Usage: make tag version=0.5.0
+tag:
+	@docker image tag victorskl/g3po:latest quay.io/umccr/g3po:$(version)
+	@docker image tag victorskl/g3po:latest quay.io/victorskl/g3po:$(version)
+	@docker image tag victorskl/g3po:latest victorskl/g3po:$(version)
+	@docker push quay.io/umccr/g3po:$(version)
+	@docker push quay.io/victorskl/g3po:$(version)
+	@docker push victorskl/g3po:$(version)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Assorted utility CLI to work with Gen3
 
+> Required: **Python 3.6, 3.7**
+
 ```
 pip install g3po
 
@@ -273,7 +275,6 @@ NOTE: this is same-as or alias to `gen3user validate user.yaml`
 
 ## Development
 
-- Python 3.6
 - Activate virtual environment
 - And install pip dependencies 
 ```

--- a/g3po/__init__.py
+++ b/g3po/__init__.py
@@ -1,6 +1,6 @@
 # Follow Python style PEP 440 https://www.python.org/dev/peps/pep-0440/
 import os
 
-__version__ = VERSION = '0.5.0'  # pragma: no cover
+__version__ = VERSION = '0.5.1'  # pragma: no cover
 
 GEN3_URL = os.getenv("GEN3_URL", "https://gen3.cloud.dev.umccr.org/")

--- a/g3po/main.py
+++ b/g3po/main.py
@@ -36,6 +36,7 @@ def check_healthy():
 
 
 @click.group()
+@click.version_option(__version__)
 def cli():
     pass
 

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,12 @@ setup(
         "dictionaryutils>=3.4.2",
         "gen3users>=0.7.0",
         "ldap3>=2.9.1",
-        "yglu>=1.1.1",
         "importlib_metadata<2.0.0",
-        "jsonschema==2.5.1"
+        "yglu>=1.1.1",
+        "jsonschema==2.5.1",
+        "setuptools",       # yglu bad setup! see https://github.com/lbovet/yglu/blob/master/setup.py
+        "setuptools_scm",   # yglu bad setup! see https://github.com/lbovet/yglu/blob/master/setup.py
+        "wheel",            # yglu bad setup! see https://github.com/lbovet/yglu/blob/master/setup.py
     ],
     extras_require={
         "test": [
@@ -40,5 +43,5 @@ setup(
             "wheel",
         ],
     },
-    python_requires=">=3.6",
+    python_requires=">=3.6,<=3.8",  # not me! see https://github.com/uc-cdis/dictionaryutils/blob/master/pyproject.toml
 )


### PR DESCRIPTION
* Patch release 0.5.1
* Added `--version` flag
* Required Python 3.6, 3.7 inherent from upstream Gen3 tooling
* Fixed build related deps due to yglu
